### PR TITLE
Fixed some bugs and added QoL features

### DIFF
--- a/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecMakeGUI.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecMakeGUI.java
@@ -166,4 +166,5 @@ public class SecMakeGUI extends EffectSection {
 				return "make gui";
 		}
 	}
+
 }

--- a/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecMakeGUI.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecMakeGUI.java
@@ -166,8 +166,4 @@ public class SecMakeGUI extends EffectSection {
 				return "make gui";
 		}
 	}
-
-	public Expression<Object> getSlots() {
-		return slots;
-	}
 }

--- a/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecMakeGUI.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecMakeGUI.java
@@ -167,4 +167,7 @@ public class SecMakeGUI extends EffectSection {
 		}
 	}
 
+	public Expression<Object> getSlots() {
+		return slots;
+	}
 }

--- a/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecSlotChange.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecSlotChange.java
@@ -63,10 +63,13 @@ public class SecSlotChange extends Section {
 	@Nullable
 	public TriggerItem walk(Event e) {
 		GUI gui = SkriptGUI.getGUIManager().getGUI(e);
+		if (gui == null)
+			return walk(e, false);
+
 		Integer[] slots = guiSlots.getAll(e);
 
 		for (Integer slot : slots) {
-			if (gui != null && slot != null && slot >= 0 && slot + 1 <= gui.getInventory().getSize()) {
+			if (slot >= 0 && slot + 1 <= gui.getInventory().getSize()) {
 				Object variables = Variables.copyLocalVariables(e);
 				GUI.SlotData slotData = gui.getSlotData(gui.convert(slot));
 				if (variables != null && slotData != null) {

--- a/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecSlotChange.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/elements/sections/SecSlotChange.java
@@ -1,0 +1,92 @@
+package io.github.apickledwalrus.skriptgui.elements.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.Section;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.Trigger;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.Kleenean;
+import io.github.apickledwalrus.skriptgui.SkriptGUI;
+import io.github.apickledwalrus.skriptgui.gui.GUI;
+import org.bukkit.event.Event;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.List;
+
+@Name("GUI Slot Change")
+@Description("Sections that will run when a gui slot is changed. This section is optional.")
+@Examples({
+		"create a gui with virtual chest inventory with 3 rows named \"My GUI\"",
+		"\trun when slot 12 changes:",
+		"\t\tsend \"You changed slot 12!\" to player",
+		"\trun on slot 14 changed:",
+		"\t\tcancel event"
+})
+@Since("1.3")
+public class SecSlotChange extends Section {
+
+	static {
+		Skript.registerSection(SecSlotChange.class,
+				"run when [gui] slot[s] %integers% change[s]",
+				"run when [gui] slot[s] %integers% [(are|is)] [being] changed",
+				"run on change of [gui] slot[s] %integers%"
+		);
+	}
+
+	@SuppressWarnings("NotNullFieldNotInitialized")
+	private Trigger trigger;
+	private Expression<Integer> guiSlots;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+		if (!getParser().isCurrentSection(SecCreateGUI.class)) {
+			Skript.error("You can't listen for changes of a slot outside of a GUI creation or editing section.");
+			return false;
+		}
+
+		trigger = loadCode(sectionNode, "inventory click", InventoryClickEvent.class);
+
+		guiSlots = (Expression<Integer>) exprs[0];
+		return true;
+	}
+
+	@Override
+	@Nullable
+	public TriggerItem walk(Event e) {
+		GUI gui = SkriptGUI.getGUIManager().getGUI(e);
+		Integer[] slots = guiSlots.getAll(e);
+
+		for (Integer slot : slots) {
+			if (gui != null && slot != null && slot >= 0 && slot + 1 <= gui.getInventory().getSize()) {
+				Object variables = Variables.copyLocalVariables(e);
+				GUI.SlotData slotData = gui.getSlotData(gui.convert(slot));
+				if (variables != null && slotData != null) {
+					slotData.setRunOnChange(event -> {
+						Variables.setLocalVariables(event, variables);
+						trigger.execute(event);
+					});
+				} else if (slotData != null) {
+					slotData.setRunOnChange(trigger::execute);
+				}
+			}
+		}
+
+		// We don't want to execute this section
+		return walk(e, false);
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "run on change of slot " + guiSlots.toString(e, debug);
+	}
+
+}

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUI.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUI.java
@@ -265,16 +265,6 @@ public class GUI {
 		return nextSlot();
 	}
 
-	public static InventoryClickEvent setClickedSlot(InventoryClickEvent event, int slot) {
-		return new InventoryClickEvent(
-				event.getView(),
-				event.getSlotType(),
-				slot,
-				event.getClick(),
-				event.getAction()
-		);
-	}
-
 	/**
 	 * @return The next available slot in this GUI.
 	 */

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUI.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUI.java
@@ -70,7 +70,7 @@ public class GUI {
 				e.setCancelled(!isRemovable(slotData));
 
 				Consumer<InventoryClickEvent> runOnChange = slotData.getRunOnChange();
-				if (runOnChange != null) {
+				if (!e.isCancelled() && runOnChange != null) {
 					SkriptGUI.getGUIManager().setGUI(e, GUI.this);
 					runOnChange.accept(e);
 				}
@@ -265,7 +265,7 @@ public class GUI {
 		return nextSlot();
 	}
 
-	public InventoryClickEvent setClickedSlot(InventoryClickEvent event, int slot) {
+	public static InventoryClickEvent setClickedSlot(InventoryClickEvent event, int slot) {
 		return new InventoryClickEvent(
 				event.getView(),
 				event.getSlotType(),

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUIEventHandler.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUIEventHandler.java
@@ -1,10 +1,7 @@
 package io.github.apickledwalrus.skriptgui.gui;
 
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryDragEvent;
-import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,8 +65,21 @@ public abstract class GUIEventHandler {
 	}
 
 	public abstract void onClick(InventoryClickEvent e);
+	public abstract void onChange(InventoryClickEvent e);
 	public abstract void onDrag(InventoryDragEvent e);
 	public abstract void onOpen(InventoryOpenEvent e);
 	public abstract void onClose(InventoryCloseEvent e);
 
+	public void onChange(InventoryDragEvent e) {
+		for (int slot : e.getInventorySlots()) {
+			InventoryClickEvent clickEvent = new InventoryClickEvent(
+					e.getView(),
+					e.getView().getSlotType(slot),
+					slot,
+					ClickType.UNKNOWN,
+					InventoryAction.UNKNOWN
+			);
+			onChange(clickEvent);
+		}
+	}
 }

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUIEventHandler.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/GUIEventHandler.java
@@ -82,4 +82,5 @@ public abstract class GUIEventHandler {
 			onChange(clickEvent);
 		}
 	}
+
 }

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
@@ -173,8 +173,8 @@ public class GUIEvents implements Listener {
 			if (item != null && item.isSimilar(cursor)) {
 				if (!gui.isRemovable(gui.convert(slot))) {
 					event.setCancelled(true);
-					clickEvents.clear();
-					break;
+					return;
+
 				}
 				if (totalAmount < cursor.getMaxStackSize()) {
 					InventoryClickEvent clickEvent = GUI.setClickedSlot(event, slot);

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
@@ -67,27 +67,25 @@ public class GUIEvents implements Listener {
 						Inventory guiInventory = gui.getInventory();
 
 						int size = guiInventory.getSize();
+						int totalAmount = clicked.getAmount();
 
 						for (int slot = 0; slot < size; slot++) {
+							if (totalAmount <= 0) {
+								return;
+							}
+
 							ItemStack item = guiInventory.getItem(slot);
-							if (item != null && item.getType() != Material.AIR && item.isSimilar(clicked)) {
+							if (item != null && item.getType() != Material.AIR && item.isSimilar(clicked) && item.getAmount() < item.getMaxStackSize()) {
 								InventoryClickEvent clickEvent = setClickedSlot(event, slot);
 
 								if (!gui.isRemovable(gui.convert(slot))) {
-									if (item.getAmount() >= item.getMaxStackSize()) { // It wouldn't be able to combine
-										continue;
-									}
 									event.setCancelled(true);
-
 									return;
-								}
-
-								if (item.getAmount() + clicked.getAmount() <= item.getMaxStackSize()) { // This will only modify a modifiable slot
+                                } else {
 									eventHandler.onChange(clickEvent);
-									return;
-								}
-
-							}
+									totalAmount -= item.getMaxStackSize() - item.getAmount();
+                                }
+                            }
 						}
 
 						int firstEmpty = guiInventory.firstEmpty();

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
@@ -197,4 +197,5 @@ public class GUIEvents implements Listener {
 				event.getAction()
 		);
 	}
+
 }

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
@@ -81,11 +81,12 @@ public class GUIEvents implements Listener {
 								if (!gui.isRemovable(gui.convert(slot))) {
 									event.setCancelled(true);
 									return;
-                                } else {
+								} else {
 									eventHandler.onChange(clickEvent);
 									totalAmount -= item.getMaxStackSize() - item.getAmount();
-                                }
-                            }
+								}
+							}
+
 						}
 
 						int firstEmpty = guiInventory.firstEmpty();

--- a/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
+++ b/src/main/java/io/github/apickledwalrus/skriptgui/gui/events/GUIEvents.java
@@ -71,7 +71,7 @@ public class GUIEvents implements Listener {
 						for (int slot = 0; slot < size; slot++) {
 							ItemStack item = guiInventory.getItem(slot);
 							if (item != null && item.getType() != Material.AIR && item.isSimilar(clicked)) {
-								InventoryClickEvent clickEvent = GUI.setClickedSlot(event, slot);
+								InventoryClickEvent clickEvent = setClickedSlot(event, slot);
 
 								if (!gui.isRemovable(gui.convert(slot))) {
 									if (item.getAmount() >= item.getMaxStackSize()) { // It wouldn't be able to combine
@@ -92,7 +92,7 @@ public class GUIEvents implements Listener {
 
 						int firstEmpty = guiInventory.firstEmpty();
 						if (firstEmpty != -1 && gui.isRemovable(gui.convert(firstEmpty))) { // Safe to be moved into the GUI
-							InventoryClickEvent clickEvent = GUI.setClickedSlot(event, firstEmpty);
+							InventoryClickEvent clickEvent = setClickedSlot(event, firstEmpty);
 							eventHandler.onChange(clickEvent);
 							return;
 						}
@@ -174,10 +174,10 @@ public class GUIEvents implements Listener {
 				if (!gui.isRemovable(gui.convert(slot))) {
 					event.setCancelled(true);
 					return;
-
 				}
+
 				if (totalAmount < cursor.getMaxStackSize()) {
-					InventoryClickEvent clickEvent = GUI.setClickedSlot(event, slot);
+					InventoryClickEvent clickEvent = setClickedSlot(event, slot);
 					clickEvents.add(clickEvent);
 					totalAmount += item.getAmount();
 				}
@@ -188,4 +188,13 @@ public class GUIEvents implements Listener {
 		}
 	}
 
+	private static InventoryClickEvent setClickedSlot(InventoryClickEvent event, int slot) {
+		return new InventoryClickEvent(
+				event.getView(),
+				event.getSlotType(),
+				slot,
+				event.getClick(),
+				event.getAction()
+		);
+	}
 }


### PR DESCRIPTION
# Changes
* Made stealable items moveable regardless whether they were in a section or no
**Why:** If someone specifically marked a slot as stealable, i see **NO** reason why this should still be cancelling the event. To move sectioned slots the slot itself has to be stealable, if the gui is stealable but the slot isn't then it won't let you move it

* Made a new **Slot Changed** section, which is triggered when a specific slot was changed
**Why:** This makes it easier to detect changes. Before, it wasn't even possible to detect when you instantly move an item from your inventory into the GUI. Most of the time, cancelling the event won't do anything in a **Slot Changed** section. You might think this is useless but it has (for me at least) alot of usecases, such as custom anvil or custom crafting table

* Some changes to the code
**Why:** Some parts were causing a warning because they weren't properly coded, such as ``if List#size == 0`` instead of ``if List#isEmpty``

For the most part, I added stuff to skript-gui. It won't affect others and would be useful in some situations. So I hope this PR get's accepted or added in some way